### PR TITLE
feat: add Prometheus metrics support and update health check routes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     implementation 'com.couponpop:couponpop-security:0.0.1-SNAPSHOT'
 
     // [CouponPop Core Module]
-    implementation 'com.couponpop:couponpop-core:0.0.2-SNAPSHOT'
+    implementation 'com.couponpop:couponpop-core:0.0.5-SNAPSHOT'
 
     // [DB]
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -158,6 +158,9 @@ dependencies {
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
+
+    // [Micrometer Prometheus Registry]
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/couponpop/memberservice/global/config/MonitoringConfig.java
+++ b/src/main/java/com/couponpop/memberservice/global/config/MonitoringConfig.java
@@ -1,0 +1,20 @@
+package com.couponpop.memberservice.global.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MonitoringConfig {
+
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> commonTags(
+            @Value("${spring.application.name}") String applicationName
+    ) {
+
+        return registry -> registry.config()
+                .commonTags("application", applicationName);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,3 @@ management:
   endpoint:
     health:
       show-details: always
-  metrics:
-    tags:
-      application: ${spring.application.name}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,5 +2,13 @@ server:
   port: 8081
 
 management:
-  endpoints.web.exposure.include: health,info
-  endpoint.health.show-details: always
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,6 +26,3 @@ management:
     web:
       exposure:
         include: health, prometheus
-  metrics:
-    tags:
-      application: ${spring.application.name}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,4 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,7 @@ jwt:
       - /api/v1/auth/signup
       - /api/v1/auth/login
       - /actuator/health
+      - /actuator/prometheus
       - /error
       - /swagger-ui/**
       - /swagger-ui.html


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- related to CouponPop/local-docker-infra#1

<br>

## 📝 **작업 내용**

- Prometheus 레지스트리 의존성 추가
- 메트릭에 대한 공통 애플리케이션 태그 구성
- `/actuator/prometheus` 경로를 JWT 화이트리스트에 추가

<br>

## 📸 **스크린샷 (선택)**

<br>
