### PR TITLE
bug: 로그아웃/회원탈퇴 시 JWT가 즉시 만료되어 FCM 토큰이 삭제되지 않는 버그 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     implementation 'com.couponpop:couponpop-security:0.0.3-SNAPSHOT'
 
     // [CouponPop Core Module]
-    implementation 'com.couponpop:couponpop-core:0.0.15-SNAPSHOT'
+    implementation 'com.couponpop:couponpop-core:0.0.21-SNAPSHOT'
 
     // [DB]
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/couponpop/memberservice/common/client/FcmTokenSystemFeignClient.java
+++ b/src/main/java/com/couponpop/memberservice/common/client/FcmTokenSystemFeignClient.java
@@ -1,12 +1,12 @@
 package com.couponpop.memberservice.common.client;
 
 import com.couponpop.couponpopcoremodule.dto.fcmtoken.request.FcmTokenExpireRequest;
-import com.couponpop.memberservice.common.config.UserFeignConfig;
+import com.couponpop.memberservice.common.config.SystemFeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 
-@FeignClient(name = "${client.notification-service.name}", url = "${client.notification-service.url}", configuration = UserFeignConfig.class)
-public interface FcmTokenUserFeignClient {
+@FeignClient(name = "${client.notification-service.name}", url = "${client.notification-service.url}", configuration = SystemFeignConfig.class)
+public interface FcmTokenSystemFeignClient {
 
     @PostMapping("/internal/v1/fcm-token/expire")
     void expireFcmToken(FcmTokenExpireRequest fcmTokenExpireRequest);

--- a/src/main/java/com/couponpop/memberservice/common/config/SystemFeignConfig.java
+++ b/src/main/java/com/couponpop/memberservice/common/config/SystemFeignConfig.java
@@ -1,0 +1,32 @@
+package com.couponpop.memberservice.common.config;
+
+import com.couponpop.security.token.SystemTokenProvider;
+import feign.RequestInterceptor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static com.couponpop.security.constants.SecurityTemplates.BEARER_TOKEN_PREFIX;
+
+/**
+ * 시스템 내부 통신을 위한 Feign Client 설정입니다.
+ * 모든 요청에 시스템 토큰을 Authorization 헤더에 추가합니다.
+ */
+@Slf4j
+@Configuration
+public class SystemFeignConfig {
+
+    /**
+     * Feign 요청에 시스템 토큰을 추가하는 RequestInterceptor를 생성합니다.
+     *
+     * @param systemTokenProvider systemTokenProvider 시스템 토큰을 제공하는 프로바이더
+     * @return RequestInterceptor Bean
+     */
+    @Bean
+    public RequestInterceptor systemTokenRequestInterceptor(SystemTokenProvider systemTokenProvider) {
+        return requestTemplate -> {
+            String systemToken = systemTokenProvider.getToken();
+            requestTemplate.header("Authorization", BEARER_TOKEN_PREFIX + systemToken);
+        };
+    }
+}

--- a/src/main/java/com/couponpop/memberservice/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/couponpop/memberservice/domain/auth/controller/AuthController.java
@@ -43,9 +43,10 @@ public class AuthController {
     @PostMapping("/logout")
     @PreAuthorize("isAuthenticated()") // auth는 모두 접근가능하므로, 로그아웃은 인증된 사용자만 접근 가능
     public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
+                                                    @CurrentMember AuthMember authMember,
                                                     @Valid @RequestBody LogoutRequest logoutRequest) {
 
-        authService.logout(authorizationHeader, logoutRequest);
+        authService.logout(authorizationHeader, authMember, logoutRequest);
         return ApiResponse.noContent();
     }
 

--- a/src/main/java/com/couponpop/memberservice/domain/auth/service/AuthService.java
+++ b/src/main/java/com/couponpop/memberservice/domain/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.couponpop.memberservice.domain.auth.service;
 
 import com.couponpop.couponpopcoremodule.dto.fcmtoken.request.FcmTokenExpireRequest;
-import com.couponpop.memberservice.common.client.FcmTokenUserFeignClient;
+import com.couponpop.memberservice.common.client.FcmTokenSystemFeignClient;
 import com.couponpop.memberservice.common.exception.GlobalException;
 import com.couponpop.memberservice.domain.auth.dto.request.LoginRequest;
 import com.couponpop.memberservice.domain.auth.dto.request.LogoutRequest;
@@ -41,7 +41,7 @@ public class AuthService {
     private final TokenBlacklistService tokenBlacklistService;
     private final ApplicationEventPublisher eventPublisher;
 
-    private final FcmTokenUserFeignClient fcmTokenUserFeignClient;
+    private final FcmTokenSystemFeignClient fcmTokenSystemFeignClient;
 
     @Transactional
     public SignUpResponse signUp(SignUpRequest signUpRequest) {
@@ -98,7 +98,7 @@ public class AuthService {
     // 트랜잭션은 DB 작업(FcmToken 삭제)만 보장하며,
     // Redis 블랙리스트 작업은 별도 (분산 트랜잭션 고려하지 않음)
     @Transactional
-    public void logout(String authorizationHeader, LogoutRequest logoutRequest) {
+    public void logout(String authorizationHeader, AuthMember authMember, LogoutRequest logoutRequest) {
 
         String resolvedToken = extractToken(authorizationHeader);
         long expirationMillis = jwtProvider.getExpirationMillis(resolvedToken);
@@ -107,8 +107,8 @@ public class AuthService {
 
         // FCM Token 만료 처리에 실패하더라도 로그아웃은 롤백하지 않음
         try {
-            FcmTokenExpireRequest fcmTokenExpireRequest = FcmTokenExpireRequest.from(logoutRequest.fcmToken());
-            fcmTokenUserFeignClient.expireFcmToken(fcmTokenExpireRequest);
+            FcmTokenExpireRequest fcmTokenExpireRequest = FcmTokenExpireRequest.of(authMember.id(), logoutRequest.fcmToken());
+            fcmTokenSystemFeignClient.expireFcmToken(fcmTokenExpireRequest);
         } catch (FeignException e) {
             log.error("[로그아웃] FCM 토큰 만료 처리 실패 - fcmToken={}, error={}", logoutRequest.fcmToken(), e.getMessage());
         }
@@ -128,8 +128,8 @@ public class AuthService {
 
         // FCM Token 만료 처리에 실패하더라도 회원탈퇴는 롤백하지 않음
         try {
-            FcmTokenExpireRequest fcmTokenExpireRequest = FcmTokenExpireRequest.from(withdrawRequest.fcmToken());
-            fcmTokenUserFeignClient.expireFcmToken(fcmTokenExpireRequest);
+            FcmTokenExpireRequest fcmTokenExpireRequest = FcmTokenExpireRequest.of(authMember.id(), withdrawRequest.fcmToken());
+            fcmTokenSystemFeignClient.expireFcmToken(fcmTokenExpireRequest);
         } catch (FeignException e) {
             log.error("[회원탈퇴] FCM 토큰 만료 처리 실패 - fcmToken={}, error={}", withdrawRequest.fcmToken(), e.getMessage());
         }

--- a/src/test/java/com/couponpop/memberservice/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/couponpop/memberservice/domain/auth/controller/AuthControllerTest.java
@@ -288,7 +288,7 @@ class AuthControllerTest {
         LogoutRequest requestDto = new LogoutRequest("testFcmToken");
 
         // authService.logout()은 void를 반환
-        doNothing().when(authService).logout(anyString(), any(LogoutRequest.class));
+        doNothing().when(authService).logout(anyString(), any(AuthMember.class), any(LogoutRequest.class));
 
         // when
         ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/couponpop/memberservice/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/couponpop/memberservice/domain/auth/service/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package com.couponpop.memberservice.domain.auth.service;
 
 import com.couponpop.couponpopcoremodule.dto.fcmtoken.request.FcmTokenExpireRequest;
-import com.couponpop.memberservice.common.client.FcmTokenUserFeignClient;
+import com.couponpop.memberservice.common.client.FcmTokenSystemFeignClient;
 import com.couponpop.memberservice.common.exception.GlobalException;
 import com.couponpop.memberservice.domain.auth.dto.request.LoginRequest;
 import com.couponpop.memberservice.domain.auth.dto.request.LogoutRequest;
@@ -57,7 +57,7 @@ class AuthServiceTest {
     private JwtProvider jwtProvider;
 
     @Mock
-    private FcmTokenUserFeignClient fcmTokenUserFeignClient;
+    private FcmTokenSystemFeignClient fcmTokenSystemFeignClient;
 
     @Mock
     private TokenBlacklistService tokenBlacklistService;
@@ -240,7 +240,7 @@ class AuthServiceTest {
             given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
 
             // when
-            authService.logout(testAuthorizationHeader, testLogoutRequest);
+            authService.logout(testAuthorizationHeader, testAuthMember, testLogoutRequest);
 
             // then
             // 1. JWT 검증
@@ -250,7 +250,7 @@ class AuthServiceTest {
 
             // 2. 토큰 삭제 호출 검증
             ArgumentCaptor<FcmTokenExpireRequest> captor = ArgumentCaptor.forClass(FcmTokenExpireRequest.class);
-            verify(fcmTokenUserFeignClient).expireFcmToken(captor.capture());
+            verify(fcmTokenSystemFeignClient).expireFcmToken(captor.capture());
             assertThat(captor.getValue().fcmToken()).isEqualTo(testLogoutRequest.fcmToken());
         }
 
@@ -265,40 +265,12 @@ class AuthServiceTest {
 
             // when & then
             GlobalException exception = assertThrows(GlobalException.class, () -> {
-                authService.logout(testAuthorizationHeader, testLogoutRequest);
+                authService.logout(testAuthorizationHeader, testAuthMember, testLogoutRequest);
             });
 
             assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_TOKEN);
-            verify(fcmTokenUserFeignClient, never()).expireFcmToken(any());
+            verify(fcmTokenSystemFeignClient, never()).expireFcmToken(any());
         }
-
-        // TODO: 필요없을 것 같긴 한데 혹시 모르니 놔두겠습니다 확인해주세요!
-//        @Test
-//        @DisplayName("로그아웃 시 FCM 토큰이 없어도 로그아웃에 성공한다.")
-//        void logoutSuccessWithoutFcmToken() {
-//
-//            // given
-//            testLogoutRequest = new LogoutRequest("testFcmToken");
-//            MemberFcmToken mockFcmToken = TestUtils.createEntity(MemberFcmToken.class, Map.of("fcmToken", "testFcmToken"));
-//
-//            given(jwtProvider.resolveToken(testAuthorizationHeader)).willReturn(testToken);
-//            given(jwtProvider.getExpirationMillis(testToken)).willReturn(testExpirationMillis);
-//
-//            given(memberFcmTokenRepository.findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken()))
-//                    .willReturn(Optional.empty());
-//
-//            // when
-//            authService.logout(testAuthorizationHeader, testLogoutRequest, testAuthMember);
-//
-//            // then
-//            // 1. JWT 검증
-//            verify(jwtProvider).resolveToken(testAuthorizationHeader);
-//            verify(jwtProvider).getExpirationMillis(testToken);
-//            verify(tokenBlacklistService).blacklistToken(testToken, testExpirationMillis);
-//
-//            // 2. FCM Token 검증
-//            verify(memberFcmTokenRepository).findByMemberIdAndFcmToken(testAuthMember.id(), testLogoutRequest.fcmToken());
-//        }
     }
 
     @Nested
@@ -338,7 +310,7 @@ class AuthServiceTest {
 
             // FCM 토큰
             ArgumentCaptor<FcmTokenExpireRequest> captor = ArgumentCaptor.forClass(FcmTokenExpireRequest.class);
-            verify(fcmTokenUserFeignClient).expireFcmToken(captor.capture());
+            verify(fcmTokenSystemFeignClient).expireFcmToken(captor.capture());
             assertThat(captor.getValue().fcmToken()).isEqualTo(testWithdrawRequest.fcmToken());
 
             // JWT
@@ -364,7 +336,7 @@ class AuthServiceTest {
 
             assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND);
 
-            verify(fcmTokenUserFeignClient, never()).expireFcmToken(any());
+            verify(fcmTokenSystemFeignClient, never()).expireFcmToken(any());
             verify(eventPublisher, never()).publishEvent(any());
         }
     }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- related to CouponPop/couponpop-notification-service#40

<br>

## 📝 **작업 내용**

- FCM 토큰 만료 처리 로직 개선
- 시스템 Feign 클라이언트 도입
- 로그아웃/회원탈퇴 API 및 서비스 로직 변경

<br>

## 📸 **스크린샷 (선택)**

<br>
