### PR TITLE
fix: FeignConfig에 `@Configuration`을 제거하여 전역 Bean 등록을 제거

### DIFF
--- a/src/main/java/com/couponpop/memberservice/common/config/SystemFeignConfig.java
+++ b/src/main/java/com/couponpop/memberservice/common/config/SystemFeignConfig.java
@@ -4,8 +4,6 @@ import com.couponpop.security.token.SystemTokenProvider;
 import feign.RequestInterceptor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 
 import static com.couponpop.security.constants.SecurityTemplates.BEARER_TOKEN_PREFIX;
 
@@ -14,7 +12,6 @@ import static com.couponpop.security.constants.SecurityTemplates.BEARER_TOKEN_PR
  * 모든 요청에 시스템 토큰을 Authorization 헤더에 추가합니다.
  */
 @Slf4j
-@Configuration
 public class SystemFeignConfig {
 
     /**
@@ -27,8 +24,6 @@ public class SystemFeignConfig {
     public RequestInterceptor systemTokenRequestInterceptor(SystemTokenProvider systemTokenProvider) {
         return requestTemplate -> {
             String systemToken = systemTokenProvider.getToken();
-            requestTemplate.headers().remove(HttpHeaders.AUTHORIZATION);
-            log.info("systemToken: {}", systemToken);
             requestTemplate.header("Authorization", BEARER_TOKEN_PREFIX + systemToken);
         };
     }

--- a/src/main/java/com/couponpop/memberservice/common/config/UserFeignConfig.java
+++ b/src/main/java/com/couponpop/memberservice/common/config/UserFeignConfig.java
@@ -5,14 +5,12 @@ import feign.RequestInterceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Slf4j
-@Configuration
 public class UserFeignConfig {
 
     /**
@@ -32,11 +30,6 @@ public class UserFeignConfig {
 
             HttpServletRequest request = attrs.getRequest();
             String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-            if (authHeader != null) {
-                log.info("authHeader: {}", authHeader);
-                return;
-            }
 
             if (StringUtils.hasText(authHeader) && authHeader.startsWith(SecurityTemplates.BEARER_TOKEN_PREFIX)) {
                 requestTemplate.header(HttpHeaders.AUTHORIZATION, authHeader);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,8 +20,6 @@ logging:
     org.springframework: INFO
     org.hibernate.SQL: WARN
     org.hibernate.orm.jdbc.bind: WARN
-    com.couponpop.notificationservice: DEBUG
-    com.couponpop.security: DEBUG
 
 cloud:
   aws:


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #이슈번호
- related to CouponPop/couponpop-notification-service#40

<br>

## 📝 **작업 내용**

- FeignConfig에 `@Configuration`을 제거하여 전역 Bean 등록을 제거
   - 전역 Bean 모두 반복문을 통해 Header에 포함되는 버그

<br>

## 📸 **스크린샷 (선택)**

<br>
